### PR TITLE
[issue #28] goal 구현

### DIFF
--- a/src/main/java/soccerfriend/controller/GoalController.java
+++ b/src/main/java/soccerfriend/controller/GoalController.java
@@ -1,0 +1,47 @@
+package soccerfriend.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import soccerfriend.dto.Goal;
+import soccerfriend.dto.SoccerMatchMember;
+import soccerfriend.exception.exception.NoPermissionException;
+import soccerfriend.service.*;
+
+import java.util.List;
+
+import static soccerfriend.exception.ExceptionInfo.NO_CLUB_PERMISSION;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/goals")
+public class GoalController {
+
+    private final ClubMemberService clubMemberService;
+    private final SoccerMatchMemberService soccerMatchMemberService;
+    private final AuthorizeService authorizeService;
+    private final soccerfriend.service.GoalService goalService;
+
+
+    @PostMapping
+    public void addGoal(@RequestBody Goal goal) {
+        int memberId = authorizeService.getMemberId();
+        int soccerMatchMemberId = goal.getSoccerMatchMemberId();
+        SoccerMatchMember soccerMatchMember = soccerMatchMemberService.getSoccerMatchMemberById(soccerMatchMemberId);
+        if (!clubMemberService.isClubLeaderOrStaff(soccerMatchMember.getClubId(), memberId)) {
+            throw new NoPermissionException(NO_CLUB_PERMISSION);
+        }
+
+        goalService.add(goal);
+    }
+
+    @GetMapping("/{id}")
+    public Goal getGoalById(@PathVariable int id) {
+        return goalService.getGoalById(id);
+    }
+
+    @GetMapping("/member/{memberId}")
+    public List<Goal> getGoalByMemberId(@PathVariable int memberId) {
+        return goalService.getGoalByMemberId(memberId);
+    }
+}

--- a/src/main/java/soccerfriend/controller/GoalController.java
+++ b/src/main/java/soccerfriend/controller/GoalController.java
@@ -23,6 +23,11 @@ public class GoalController {
     private final soccerfriend.service.GoalService goalService;
 
 
+    /**
+     * club의 운영진이 골에 대한 정보를 추가합니다.
+     *
+     * @param goal 골에 대한 정보
+     */
     @PostMapping
     public void addGoal(@RequestBody Goal goal) {
         int memberId = authorizeService.getMemberId();
@@ -35,11 +40,23 @@ public class GoalController {
         goalService.add(goal);
     }
 
+    /**
+     * 특정 id의 골을 조회합니다.
+     *
+     * @param id goal의 id
+     * @return
+     */
     @GetMapping("/{id}")
     public Goal getGoalById(@PathVariable int id) {
         return goalService.getGoalById(id);
     }
 
+    /**
+     * 특정 member가 현재까지 넣은 모든 골에 대한 정보를 조회합니다.
+     *
+     * @param memberId member의 id
+     * @return member가 지금까지 넣은 골
+     */
     @GetMapping("/member/{memberId}")
     public List<Goal> getGoalByMemberId(@PathVariable int memberId) {
         return goalService.getGoalByMemberId(memberId);

--- a/src/main/java/soccerfriend/controller/SoccerMatchController.java
+++ b/src/main/java/soccerfriend/controller/SoccerMatchController.java
@@ -2,6 +2,7 @@ package soccerfriend.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import soccerfriend.dto.Goal;
 import soccerfriend.dto.SoccerMatch;
 import soccerfriend.dto.SoccerMatchMember;
 import soccerfriend.dto.SoccerMatchRecruitment;
@@ -181,7 +182,6 @@ public class SoccerMatchController {
         int memberId = authorizeService.getMemberId();
         SoccerMatchMember soccerMatchMember = soccerMatchMemberService.getSoccerMatchMemberById(soccerMatchMemberId);
         int clubId = soccerMatchMember.getClubId();
-
         if (!clubMemberService.isClubLeaderOrStaff(clubId, memberId)) {
             throw new NoPermissionException(NO_CLUB_PERMISSION);
         }

--- a/src/main/java/soccerfriend/dto/Goal.java
+++ b/src/main/java/soccerfriend/dto/Goal.java
@@ -14,18 +14,18 @@ public class Goal {
 
     private int soccerMatchMemberId;
 
-    private int setNumber;
+    private int numSet;
 
-    private int setTime;
+    private int timeSet;
 
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;
 
     @Builder
-    public Goal(int soccerMatchMemberId, int setNumber, int setTime) {
+    public Goal(int soccerMatchMemberId, int numSet, int timeSet) {
         this.soccerMatchMemberId = soccerMatchMemberId;
-        this.setNumber = setNumber;
-        this.setTime = setTime;
+        this.numSet = numSet;
+        this.timeSet = timeSet;
     }
 }

--- a/src/main/java/soccerfriend/dto/Goal.java
+++ b/src/main/java/soccerfriend/dto/Goal.java
@@ -1,0 +1,31 @@
+package soccerfriend.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Goal {
+
+    private int id;
+
+    private int soccerMatchMemberId;
+
+    private int setNumber;
+
+    private int setTime;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Goal(int soccerMatchMemberId, int setNumber, int setTime) {
+        this.soccerMatchMemberId = soccerMatchMemberId;
+        this.setNumber = setNumber;
+        this.setTime = setTime;
+    }
+}

--- a/src/main/java/soccerfriend/dto/SoccerMatchRecruitment.java
+++ b/src/main/java/soccerfriend/dto/SoccerMatchRecruitment.java
@@ -19,9 +19,9 @@ public class SoccerMatchRecruitment {
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     LocalDateTime endTime;
 
-    int setNumber;
+    int numSet;
 
-    int setTime;
+    int timeSet;
 
     int stadiumId;
 
@@ -34,11 +34,11 @@ public class SoccerMatchRecruitment {
     LocalDateTime updatedAt;
 
     @Builder
-    public SoccerMatchRecruitment(LocalDateTime startTime, LocalDateTime endTime, int setNumber, int setTime, int stadiumId) {
+    public SoccerMatchRecruitment(LocalDateTime startTime, LocalDateTime endTime, int numSet, int timeSet, int stadiumId) {
         this.startTime = startTime;
         this.endTime = endTime;
-        this.setNumber = setNumber;
-        this.setTime = setTime;
+        this.numSet = numSet;
+        this.timeSet = timeSet;
         this.stadiumId = stadiumId;
     }
 }

--- a/src/main/java/soccerfriend/exception/ExceptionInfo.java
+++ b/src/main/java/soccerfriend/exception/ExceptionInfo.java
@@ -13,6 +13,8 @@ public enum ExceptionInfo {
     NOT_CLUB_MEMBER(401, "해당 클럽의 회원이 아닙니다."),
     IS_CLUB_LEADER(401, "해당 클럽의 leader는 탈퇴할 수 없습니다."),
 
+    NOT_PROPER_GOAL(404, "골에 대한 정보가 정확하지 않습니다. 세트와 시간을 다시 확인해주세요."),
+    GOAL_NOT_EXIST(404, "존재하지 않은 골입니다."),
     SOCCER_MATCH_MEMBER_NOT_EXIST(404, "존재하지 않은 경기참가선수입니다."),
     SOCCER_MATCH_RECRUITMENT_NOT_EXIST(404, "존재하지 않은 경기모집공고입니다."),
     CLUB_NOT_EXIST_ON_SOCCER_MATCH(404, "해당 경기에 참여하지 않는 클럽입니다."),

--- a/src/main/java/soccerfriend/mapper/GoalMapper.java
+++ b/src/main/java/soccerfriend/mapper/GoalMapper.java
@@ -1,0 +1,17 @@
+package soccerfriend.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import soccerfriend.dto.Goal;
+
+import java.util.List;
+
+
+@Mapper
+public interface GoalMapper {
+
+    public void insert(Goal goal);
+
+    public Goal getGoalById(int id);
+
+    public List<Goal> getGoalByMemberId(int memberId);
+}

--- a/src/main/java/soccerfriend/service/GoalService.java
+++ b/src/main/java/soccerfriend/service/GoalService.java
@@ -35,19 +35,19 @@ public class GoalService {
         int soccerMatchId = soccerMatchMember.getSoccerMatchId();
         int clubId = soccerMatchMember.getClubId();
 
-        if (goal.getSetNumber() > soccerMatchRecruitment.getSetNumber() || goal.getSetNumber() < 1) {
+        if (goal.getNumSet() > soccerMatchRecruitment.getNumSet() || goal.getNumSet() < 1) {
             throw new BadRequestException(NOT_PROPER_GOAL);
         }
-        if (goal.getSetTime() > soccerMatchRecruitment.getSetTime() || goal.getSetTime() < 0) {
+        if (goal.getTimeSet() > soccerMatchRecruitment.getTimeSet() || goal.getTimeSet() < 0) {
             throw new BadRequestException(NOT_PROPER_GOAL);
         }
 
         mapper.insert(goal);
-        if (soccerMatchRecruitment.getClub1Id() == clubId) {
-            soccerMatchService.increaseClub1Score(soccerMatchId);
+        if (soccerMatchRecruitment.getHostClubId() == clubId) {
+            soccerMatchService.increaseHostClubScore(soccerMatchId);
         }
-        else if (soccerMatchRecruitment.getClub2Id() == clubId) {
-            soccerMatchService.increaseClub2Score(soccerMatchId);
+        else if (soccerMatchRecruitment.getParticipationClubId() == clubId) {
+            soccerMatchService.increaseParticipationClubScore(soccerMatchId);
         }
         else {
             throw new BadRequestException(NOT_CLUB_OF_SOCCER_MATCH);

--- a/src/main/java/soccerfriend/service/GoalService.java
+++ b/src/main/java/soccerfriend/service/GoalService.java
@@ -1,0 +1,87 @@
+package soccerfriend.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import soccerfriend.dto.Goal;
+import soccerfriend.dto.SoccerMatch;
+import soccerfriend.dto.SoccerMatchMember;
+import soccerfriend.dto.SoccerMatchRecruitment;
+import soccerfriend.exception.ExceptionInfo;
+import soccerfriend.exception.exception.BadRequestException;
+import soccerfriend.mapper.GoalMapper;
+
+import java.util.List;
+
+import static soccerfriend.exception.ExceptionInfo.*;
+
+@Service
+@RequiredArgsConstructor
+public class GoalService {
+    private final GoalMapper mapper;
+    private final SoccerMatchMemberService soccerMatchMemberService;
+    private final SoccerMatchService soccerMatchService;
+    private final SoccerMatchRecruitmentService soccerMatchRecruitmentService;
+
+    /**
+     * 경기에서 넣은 골에 대한 정보를 추가합니다. 이 때 soccerMatch의 득점 정보가 동시에 변경됩니다.
+     *
+     * @param goal 골의 정보
+     */
+    @Transactional
+    public void add(Goal goal) {
+        SoccerMatchMember soccerMatchMember = soccerMatchMemberService.getSoccerMatchMemberById(goal.getSoccerMatchMemberId());
+        SoccerMatch soccerMatch = soccerMatchService.getSoccerMatchById(soccerMatchMember.getSoccerMatchId());
+        SoccerMatchRecruitment soccerMatchRecruitment = soccerMatchRecruitmentService.getSoccerMatchRecruitmentById(soccerMatch.getSoccerMatchRecruitmentId());
+        int soccerMatchId = soccerMatchMember.getSoccerMatchId();
+        int clubId = soccerMatchMember.getClubId();
+
+        if (goal.getSetNumber() > soccerMatchRecruitment.getSetNumber() || goal.getSetNumber() < 1) {
+            throw new BadRequestException(NOT_PROPER_GOAL);
+        }
+        if (goal.getSetTime() > soccerMatchRecruitment.getSetTime() || goal.getSetTime() < 0) {
+            throw new BadRequestException(NOT_PROPER_GOAL);
+        }
+
+        mapper.insert(goal);
+        if (soccerMatchRecruitment.getClub1Id() == clubId) {
+            soccerMatchService.increaseClub1Score(soccerMatchId);
+        }
+        else if (soccerMatchRecruitment.getClub2Id() == clubId) {
+            soccerMatchService.increaseClub2Score(soccerMatchId);
+        }
+        else {
+            throw new BadRequestException(NOT_CLUB_OF_SOCCER_MATCH);
+        }
+    }
+
+    /**
+     * 특정 id의 goal을 반환합니다.
+     *
+     * @param id goal 의 id
+     * @return 특정 id의 goal
+     */
+    public Goal getGoalById(int id) {
+        Goal goal = mapper.getGoalById(id);
+        if (goal == null) {
+            throw new BadRequestException(GOAL_NOT_EXIST);
+        }
+
+        return goal;
+    }
+
+    /**
+     * 특정 member가 지금까지 넣은 모든 goal에 대한 정보를 반환합니다.
+     *
+     * @param memberId
+     * @return
+     */
+    public List<Goal> getGoalByMemberId(int memberId) {
+        List<Goal> goal = mapper.getGoalByMemberId(memberId);
+        if (goal.isEmpty()) {
+            throw new BadRequestException(GOAL_NOT_EXIST);
+        }
+
+        return goal;
+    }
+}

--- a/src/main/java/soccerfriend/service/GoalService.java
+++ b/src/main/java/soccerfriend/service/GoalService.java
@@ -7,7 +7,6 @@ import soccerfriend.dto.Goal;
 import soccerfriend.dto.SoccerMatch;
 import soccerfriend.dto.SoccerMatchMember;
 import soccerfriend.dto.SoccerMatchRecruitment;
-import soccerfriend.exception.ExceptionInfo;
 import soccerfriend.exception.exception.BadRequestException;
 import soccerfriend.mapper.GoalMapper;
 

--- a/src/main/java/soccerfriend/service/SoccerMatchRecruitmentService.java
+++ b/src/main/java/soccerfriend/service/SoccerMatchRecruitmentService.java
@@ -28,8 +28,8 @@ public class SoccerMatchRecruitmentService {
                 SoccerMatchRecruitment.builder()
                                       .startTime(soccerMatchRecruitment.getStartTime())
                                       .endTime(soccerMatchRecruitment.getEndTime())
-                                      .setTime(soccerMatchRecruitment.getSetTime())
-                                      .setNumber(soccerMatchRecruitment.getSetNumber())
+                                      .timeSet(soccerMatchRecruitment.getTimeSet())
+                                      .numSet(soccerMatchRecruitment.getNumSet())
                                       .stadiumId(soccerMatchRecruitment.getStadiumId())
                                       .hostClubId(clubId)
                                       .build();

--- a/src/main/resources/mapper/ClubMapper.xml
+++ b/src/main/resources/mapper/ClubMapper.xml
@@ -7,7 +7,7 @@
     <insert id="insert" parameterType="soccerfriend.dto.Club">
         INSERT
         INTO club(name, leader, address_id, point, monthly_fee, payment_day, created_at, updated_at)
-        VALUES (#{name}, #{leader}, #{addressId}, #{point}, #{monthlyFee}, #{paymentDay} now(), now())
+        VALUES (#{name}, #{leader}, #{addressId}, #{point}, #{monthlyFee}, #{paymentDay}, now(), now())
     </insert>
 
     <select id="getClubById" resultType="soccerfriend.dto.Club">

--- a/src/main/resources/mapper/GoalMapper.xml
+++ b/src/main/resources/mapper/GoalMapper.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="soccerfriend.mapper.GoalMapper">
+
+    <insert id="insert" parameterType="soccerfriend.dto.Goal">
+        INSERT
+        INTO goal(soccer_match_member_id, set_number, set_time, created_at, updated_at)
+        VALUES (#{soccerMatchMemberId}, #{setNumber}, #{setTime}, now(), now())
+    </insert>
+
+    <select id="getGoalById" resultType="soccerfriend.dto.Goal">
+        SELECT id, soccer_match_member_id, set_number, set_time, created_at, updated_at
+        FROM goal
+        WHERE id = #{id}
+    </select>
+
+    <select id="getGoalByMemberId" resultType="soccerfriend.dto.Goal">
+        SELECT a.id, a.soccer_match_member_id, a.set_number, a.set_time, a.created_at, a.updated_at
+        FROM goal a
+                 INNER JOIN soccer_match_member b ON a.soccer_match_member_id = b.id
+        WHERE b.member_id = #{memberId}
+    </select>
+</mapper>

--- a/src/main/resources/mapper/GoalMapper.xml
+++ b/src/main/resources/mapper/GoalMapper.xml
@@ -6,18 +6,18 @@
 
     <insert id="insert" parameterType="soccerfriend.dto.Goal">
         INSERT
-        INTO goal(soccer_match_member_id, set_number, set_time, created_at, updated_at)
-        VALUES (#{soccerMatchMemberId}, #{setNumber}, #{setTime}, now(), now())
+        INTO goal(soccer_match_member_id, num_set, time_set, created_at, updated_at)
+        VALUES (#{soccerMatchMemberId}, #{numSet}, #{timeSet}, now(), now())
     </insert>
 
     <select id="getGoalById" resultType="soccerfriend.dto.Goal">
-        SELECT id, soccer_match_member_id, set_number, set_time, created_at, updated_at
+        SELECT id, soccer_match_member_id, num_set, time_set, created_at, updated_at
         FROM goal
         WHERE id = #{id}
     </select>
 
     <select id="getGoalByMemberId" resultType="soccerfriend.dto.Goal">
-        SELECT a.id, a.soccer_match_member_id, a.set_number, a.set_time, a.created_at, a.updated_at
+        SELECT a.id, a.soccer_match_member_id, a.num_set, a.time_set, a.created_at, a.updated_at
         FROM goal a
                  INNER JOIN soccer_match_member b ON a.soccer_match_member_id = b.id
         WHERE b.member_id = #{memberId}

--- a/src/main/resources/mapper/SoccerMatchRecruitmentMapper.xml
+++ b/src/main/resources/mapper/SoccerMatchRecruitmentMapper.xml
@@ -6,16 +6,18 @@
 
     <insert id="insert" parameterType="soccerfriend.dto.SoccerMatchRecruitment">
         INSERT
-        INTO soccer_match_recruitment(start_time, end_time, set_number, set_time, stadium_id, host_club_id, participation_club_id,
+        INTO soccer_match_recruitment(start_time, end_time, num_set, time_set, stadium_id, host_club_id,
+                                      participation_club_id,
                                       created_at, updated_at)
-        VALUES (#{startTime}, #{endTime}, #{setNumber}, #{setTime}, #{stadiumId}, #{hostClubId}, #{participationClubId}, now(), now())
+        VALUES (#{startTime}, #{endTime}, #{numSet}, #{timeSet}, #{stadiumId}, #{hostClubId}, #{participationClubId},
+                now(), now())
     </insert>
 
     <select id="getSoccerMatchRecruitmentById" resultType="soccerfriend.dto.SoccerMatchRecruitment">
         SELECT start_time,
                end_time,
-               set_number,
-               set_time,
+               num_set,
+               time_set,
                stadium_id,
                host_club_id,
                participation_club_id,
@@ -28,8 +30,8 @@
     <select id="getSoccerMatchRecruitmentByClubId" resultType="soccerfriend.dto.SoccerMatchRecruitment">
         SELECT start_time,
                end_time,
-               set_number,
-               set_time,
+               num_set,
+               time_set,
                stadium_id,
                host_club_id,
                participation_club_id,
@@ -44,8 +46,8 @@
         UPDATE soccer_match_recruitment
         SET start_time = #{request.startTime},
             end_time   = #{request.endTime},
-            set_number = #{request.setNumber},
-            set_time   = #{request.setTime},
+            num_set    = #{request.numSet},
+            time_set   = #{request.timeSet},
             stadium_id = #{request.stadiumId},
             updated_at=now()
         WHERE id = #{id}
@@ -53,7 +55,7 @@
 
     <update id="setParticipationClubId">
         UPDATE soccer_match_recruitment
-        SET participation_club_id  = #{participationClubId},
+        SET participation_club_id = #{participationClubId},
             updated_at=now()
         WHERE id = #{id}
     </update>


### PR DESCRIPTION
issue #28 

### 변경 사항
- club의 운영진은 경기의 골 정보를 추가할 수 있음
- 골을 추가할 때 soccerMatch의 득점 정보가 실시간으로 변동됨 (현재 추가만 구현 삭제는 추후에 삭제 구현방법 연구후 다시 진행예정)
- 특정 member가 넣은 goal 및 id를 통해 goal을 조회할 수 있음
