### PR TITLE
[issue #51] bulletin 이름 변경기능 추가

### DIFF
--- a/src/main/java/soccerfriend/authentication/AuthInterceptor.java
+++ b/src/main/java/soccerfriend/authentication/AuthInterceptor.java
@@ -34,6 +34,7 @@ public class AuthInterceptor implements HandlerInterceptor {
         MemberLoginCheck memberLoginCheck = ((HandlerMethod) handler).getMethodAnnotation(MemberLoginCheck.class);
         BulletinChangeable bulletinChangeable = ((HandlerMethod) handler).getMethodAnnotation(BulletinChangeable.class);
         BulletinReadable bulletinReadable = ((HandlerMethod) handler).getMethodAnnotation(BulletinReadable.class);
+        IsClubLeaderOrManager isClubLeaderOrManager = ((HandlerMethod) handler).getMethodAnnotation(IsClubLeaderOrManager.class);
         Map<String, String> pathVariables =
                 (Map<String, String>) request
                         .getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
@@ -63,6 +64,18 @@ public class AuthInterceptor implements HandlerInterceptor {
 
             int memberId = loginService.getMemberId();
             int clubId = bulletinService.getBulletinById(bulletinId).getClubId();
+            if (!clubMemberService.isClubLeaderOrStaff(clubId, memberId)) {
+                throw new NoPermissionException(NO_CLUB_PERMISSION);
+            }
+        }
+
+        if (isClubLeaderOrManager != null) {
+            Integer clubId = Integer.valueOf(pathVariables.get("clubId"));
+            if (clubId == null) {
+                throw new BadRequestException(CLUB_NOT_EXIST);
+            }
+
+            int memberId = loginService.getMemberId();
             if (!clubMemberService.isClubLeaderOrStaff(clubId, memberId)) {
                 throw new NoPermissionException(NO_CLUB_PERMISSION);
             }

--- a/src/main/java/soccerfriend/authentication/AuthInterceptor.java
+++ b/src/main/java/soccerfriend/authentication/AuthInterceptor.java
@@ -8,6 +8,7 @@ import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.HandlerMapping;
 import soccerfriend.exception.exception.BadRequestException;
 import soccerfriend.exception.exception.NoPermissionException;
+import soccerfriend.service.BulletinService;
 import soccerfriend.service.ClubMemberService;
 import soccerfriend.service.LoginService;
 
@@ -15,8 +16,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Map;
 
-import static soccerfriend.exception.ExceptionInfo.CLUB_NOT_EXIST;
-import static soccerfriend.exception.ExceptionInfo.NO_CLUB_PERMISSION;
+import static soccerfriend.exception.ExceptionInfo.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -25,55 +25,49 @@ public class AuthInterceptor implements HandlerInterceptor {
 
     private final LoginService loginService;
     private final ClubMemberService clubMemberService;
+    private final BulletinService bulletinService;
+
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
 
         MemberLoginCheck memberLoginCheck = ((HandlerMethod) handler).getMethodAnnotation(MemberLoginCheck.class);
-        IsClubLeaderOrManager isClubLeaderOrManager = ((HandlerMethod) handler).getMethodAnnotation(IsClubLeaderOrManager.class);
-        IsClubMember isClubMember = ((HandlerMethod) handler).getMethodAnnotation(IsClubMember.class);
+        BulletinChangeable bulletinChangeable = ((HandlerMethod) handler).getMethodAnnotation(BulletinChangeable.class);
+        BulletinReadable bulletinReadable = ((HandlerMethod) handler).getMethodAnnotation(BulletinReadable.class);
+        Map<String, String> pathVariables =
+                (Map<String, String>) request
+                        .getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
 
         if (memberLoginCheck != null) {
             loginService.getMemberId();
         }
 
-        if (isClubMember != null) {
-            Map<String, String> pathVariables =
-                    (Map<String, String>) request
-                            .getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        if (bulletinReadable != null) {
+            Integer bulletinId = Integer.parseInt(pathVariables.get("id"));
+            if (bulletinId == null) {
+                throw new BadRequestException(BULLETIN_NOT_EXIST);
+            }
 
             int memberId = loginService.getMemberId();
-            String clubIdVariable = pathVariables.get("clubId");
-            clubPathVariableCheck(clubIdVariable);
-            int clubId = Integer.parseInt(clubIdVariable);
-
+            int clubId = bulletinService.getBulletinById(bulletinId).getClubId();
             if (!clubMemberService.isClubMember(clubId, memberId)) {
                 throw new NoPermissionException(NO_CLUB_PERMISSION);
             }
         }
 
-        if (isClubLeaderOrManager != null) {
-            Map<String, String> pathVariables =
-                    (Map<String, String>) request
-                            .getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        if (bulletinChangeable != null) {
+            Integer bulletinId = Integer.parseInt(pathVariables.get("id"));
+            if (bulletinId == null) {
+                throw new BadRequestException(BULLETIN_NOT_EXIST);
+            }
 
             int memberId = loginService.getMemberId();
-            String clubIdVariable = pathVariables.get("clubId");
-            clubPathVariableCheck(clubIdVariable);
-            Integer clubId = Integer.parseInt(clubIdVariable);
-
+            int clubId = bulletinService.getBulletinById(bulletinId).getClubId();
             if (!clubMemberService.isClubLeaderOrStaff(clubId, memberId)) {
                 throw new NoPermissionException(NO_CLUB_PERMISSION);
             }
         }
 
         return true;
-    }
-
-    private void clubPathVariableCheck(String pathVariable) {
-        if (pathVariable == null) {
-            log.warn("PathVaribale에 club 정보가 없습니다.");
-            throw new BadRequestException(CLUB_NOT_EXIST);
-        }
     }
 }

--- a/src/main/java/soccerfriend/authentication/BulletinChangeable.java
+++ b/src/main/java/soccerfriend/authentication/BulletinChangeable.java
@@ -6,10 +6,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * 현재 로그인한 member가 PathVariable에 존재하는 clubId의 운영진인지 확인합니다.
- * PathVaribale로 clubId를 제공받아야합니다.
+ * 현재 로그인한 member가 bulletin에서 변경 권한이 있는지 확인합니다.
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface IsClubLeaderOrManager {
+public @interface BulletinChangeable {
 }

--- a/src/main/java/soccerfriend/authentication/BulletinReadable.java
+++ b/src/main/java/soccerfriend/authentication/BulletinReadable.java
@@ -6,10 +6,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * 현재 로그인한 member가 PathVariable에 존재하는 clubId의 회원인지 확인합니다.
- * PathVaribale로 clubId를 제공받아야합니다.
+ * 현재 로그인한 member가 bulletin에서 읽기 권한이 있는지 확인합니다.
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface IsClubMember {
+public @interface BulletinReadable {
 }

--- a/src/main/java/soccerfriend/authentication/IsClubLeaderOrManager.java
+++ b/src/main/java/soccerfriend/authentication/IsClubLeaderOrManager.java
@@ -1,0 +1,15 @@
+package soccerfriend.authentication;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 현재 로그인한 member가 PathVariable에 존재하는 clubId의 운영진인지 확인합니다.
+ * PathVaribale로 clubId를 제공받아야합니다.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IsClubLeaderOrManager {
+}

--- a/src/main/java/soccerfriend/controller/BulletinController.java
+++ b/src/main/java/soccerfriend/controller/BulletinController.java
@@ -3,8 +3,8 @@ package soccerfriend.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import soccerfriend.authentication.IsClubLeaderOrManager;
-import soccerfriend.authentication.IsClubMember;
+import soccerfriend.authentication.BulletinChangeable;
+import soccerfriend.authentication.BulletinReadable;
 import soccerfriend.dto.Bulletin;
 import soccerfriend.service.BulletinService;
 
@@ -25,7 +25,7 @@ public class BulletinController {
      * @param bulletin 새로 추가할 게시판의 정보
      */
     @PostMapping("/club/{clubId}")
-    @IsClubLeaderOrManager
+    @BulletinChangeable
     public void create(@PathVariable int clubId, @Validated @RequestBody Bulletin bulletin) {
         bulletinService.create(clubId, bulletin);
     }
@@ -36,8 +36,8 @@ public class BulletinController {
      * @param clubId 게시판을 삭제할 클럽의 id
      * @param id     삭제할 게시판의 id
      */
-    @DeleteMapping("/club/{clubId}/{id}")
-    @IsClubLeaderOrManager
+    @DeleteMapping("/{id}")
+    @BulletinChangeable
     public void delete(@PathVariable int clubId, @PathVariable int id) {
         bulletinService.delete(id);
     }
@@ -49,7 +49,7 @@ public class BulletinController {
      * @return 특정 클럽에 존재하는 모든 게시판의 정보
      */
     @GetMapping("/club/{clubId}")
-    @IsClubMember
+    @BulletinReadable
     public List<Bulletin> getBulletinsByClubId(@PathVariable int clubId) {
         return bulletinService.getBulletinsByClubId(clubId);
     }
@@ -57,13 +57,12 @@ public class BulletinController {
     /**
      * 클럽에 존재하는 특정 id의 게시판을 반환합니다.
      *
-     * @param clubId 클럽의 id
      * @param id     게시판의 id
      * @return 클럽에 존재하는 특정 id의 게시판
      */
-    @GetMapping("/club/{clubId}/{id}")
-    @IsClubMember
-    public Bulletin getBulletinById(@PathVariable int clubId, @PathVariable int id) {
+    @GetMapping("/{id}")
+    @BulletinReadable
+    public Bulletin getBulletinById(@PathVariable int id) {
         return bulletinService.getBulletinById(id);
     }
 
@@ -75,7 +74,7 @@ public class BulletinController {
      * @param name 새로운 게시판 이름
      */
     @PatchMapping("/club/{clubId}/{id}")
-    @IsClubLeaderOrManager
+    @BulletinChangeable
     public void updateName(@PathVariable int clubId,
                            @PathVariable int id,
                            @RequestParam @Size(min = 1, max = 16) String name) {

--- a/src/main/java/soccerfriend/controller/BulletinController.java
+++ b/src/main/java/soccerfriend/controller/BulletinController.java
@@ -5,6 +5,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import soccerfriend.authentication.BulletinChangeable;
 import soccerfriend.authentication.BulletinReadable;
+import soccerfriend.authentication.IsClubLeaderOrManager;
 import soccerfriend.dto.Bulletin;
 import soccerfriend.service.BulletinService;
 
@@ -25,7 +26,7 @@ public class BulletinController {
      * @param bulletin 새로 추가할 게시판의 정보
      */
     @PostMapping("/club/{clubId}")
-    @BulletinChangeable
+    @IsClubLeaderOrManager
     public void create(@PathVariable int clubId, @Validated @RequestBody Bulletin bulletin) {
         bulletinService.create(clubId, bulletin);
     }
@@ -33,12 +34,11 @@ public class BulletinController {
     /**
      * 클럽에 있는 게시판을 삭제합니다.
      *
-     * @param clubId 게시판을 삭제할 클럽의 id
-     * @param id     삭제할 게시판의 id
+     * @param id 삭제할 게시판의 id
      */
     @DeleteMapping("/{id}")
     @BulletinChangeable
-    public void delete(@PathVariable int clubId, @PathVariable int id) {
+    public void delete(@PathVariable int id) {
         bulletinService.delete(id);
     }
 
@@ -57,7 +57,7 @@ public class BulletinController {
     /**
      * 클럽에 존재하는 특정 id의 게시판을 반환합니다.
      *
-     * @param id     게시판의 id
+     * @param id 게시판의 id
      * @return 클럽에 존재하는 특정 id의 게시판
      */
     @GetMapping("/{id}")
@@ -69,14 +69,12 @@ public class BulletinController {
     /**
      * 클럽에 존재하는 게시판의 이름을 변경합니다.
      *
-     * @param clubId 클럽의 id
-     * @param id 게시판의 id
+     * @param id   게시판의 id
      * @param name 새로운 게시판 이름
      */
-    @PatchMapping("/club/{clubId}/{id}")
+    @PatchMapping("/{id}")
     @BulletinChangeable
-    public void updateName(@PathVariable int clubId,
-                           @PathVariable int id,
+    public void updateName(@PathVariable int id,
                            @RequestParam @Size(min = 1, max = 16) String name) {
         bulletinService.updateName(id, name);
     }

--- a/src/main/java/soccerfriend/controller/BulletinController.java
+++ b/src/main/java/soccerfriend/controller/BulletinController.java
@@ -8,6 +8,7 @@ import soccerfriend.authentication.IsClubMember;
 import soccerfriend.dto.Bulletin;
 import soccerfriend.service.BulletinService;
 
+import javax.validation.constraints.Size;
 import java.util.List;
 
 @RestController
@@ -57,12 +58,27 @@ public class BulletinController {
      * 클럽에 존재하는 특정 id의 게시판을 반환합니다.
      *
      * @param clubId 클럽의 id
-     * @param id 게시판의 id
+     * @param id     게시판의 id
      * @return 클럽에 존재하는 특정 id의 게시판
      */
     @GetMapping("/club/{clubId}/{id}")
     @IsClubMember
     public Bulletin getBulletinById(@PathVariable int clubId, @PathVariable int id) {
         return bulletinService.getBulletinById(id);
+    }
+
+    /**
+     * 클럽에 존재하는 게시판의 이름을 변경합니다.
+     *
+     * @param clubId 클럽의 id
+     * @param id 게시판의 id
+     * @param name 새로운 게시판 이름
+     */
+    @PatchMapping("/club/{clubId}/{id}")
+    @IsClubLeaderOrManager
+    public void updateName(@PathVariable int clubId,
+                           @PathVariable int id,
+                           @RequestParam @Size(min = 1, max = 16) String name) {
+        bulletinService.updateName(id, name);
     }
 }

--- a/src/main/java/soccerfriend/exception/ExceptionInfo.java
+++ b/src/main/java/soccerfriend/exception/ExceptionInfo.java
@@ -44,6 +44,7 @@ public enum ExceptionInfo {
     PAYER_TYPE_NOT_EXIST(404, "결제 대상이 아닙니다."),
 
 
+    SAME_NAME_FOR_UPDATE(409, "이전과 동일한 이름입니다."),
     CLUB_BULLETINS_FULL(409, "클럽내 게시판 개수가 최대입니다."),
     BULLETIN_NAME_DUPLICATED(409, "이미 존재하는 게시판 이름입니다."),
     CODE_INCORRECT(409, "일치하지 않은 코드입니다."),

--- a/src/main/java/soccerfriend/mapper/BulletinMapper.java
+++ b/src/main/java/soccerfriend/mapper/BulletinMapper.java
@@ -23,4 +23,6 @@ public interface BulletinMapper {
     public Bulletin getBulletinById(int id);
 
     public List<Bulletin> getBulletinsByClubId(int clubId);
+
+    public void updateName(@Param("id") int id, @Param("name") String name);
 }

--- a/src/main/java/soccerfriend/mapper/ClubMemberMapper.java
+++ b/src/main/java/soccerfriend/mapper/ClubMemberMapper.java
@@ -34,5 +34,7 @@ public interface ClubMemberMapper {
     public List<ClubMember> getPaidClubMembers(@Param("clubId") int clubId, @Param("year") int year, @Param("month") int month);
 
     public List<ClubMember> getNotPaidClubMembers(@Param("clubId") int clubId, @Param("year") int year, @Param("month") int month);
+
+    public List<Integer> getClubIdOfMember(int memberId);
 }
 

--- a/src/main/java/soccerfriend/service/ClubMemberService.java
+++ b/src/main/java/soccerfriend/service/ClubMemberService.java
@@ -9,7 +9,8 @@ import soccerfriend.mapper.ClubMemberMapper;
 
 import java.util.List;
 
-import static soccerfriend.dto.ClubMember.ClubMemberGrade.*;
+import static soccerfriend.dto.ClubMember.ClubMemberGrade.LEADER;
+import static soccerfriend.dto.ClubMember.ClubMemberGrade.MEMBER;
 import static soccerfriend.exception.ExceptionInfo.*;
 
 @Service
@@ -215,5 +216,20 @@ public class ClubMemberService {
      */
     public List<ClubMember> getNotPaidClubMembers(int clubId, int year, int month) {
         return mapper.getNotPaidClubMembers(clubId, year, month);
+    }
+
+    /**
+     * 특정 member가 속한 모든 club의 id들을 반환합니다.
+     *
+     * @param memberId member의 id
+     * @return member가 속한 club의 id
+     */
+    public List<Integer> getClubIdOfMember(int memberId) {
+        List<Integer> clubIdOfMember = mapper.getClubIdOfMember(memberId);
+        if (clubIdOfMember.isEmpty()) {
+            throw new BadRequestException(NOT_CLUB_MEMBER);
+        }
+
+        return clubIdOfMember;
     }
 }

--- a/src/main/java/soccerfriend/service/LoginService.java
+++ b/src/main/java/soccerfriend/service/LoginService.java
@@ -1,6 +1,6 @@
 package soccerfriend.service;
 
-import static soccerfriend.utility.InputForm.*;
+import static soccerfriend.utility.InputForm.LoginRequest;
 
 public interface LoginService {
 

--- a/src/main/java/soccerfriend/service/SessionLoginService.java
+++ b/src/main/java/soccerfriend/service/SessionLoginService.java
@@ -24,7 +24,6 @@ public class SessionLoginService implements LoginService {
     private final HttpSession httpSession;
     private final MemberService memberService;
     private final StadiumOwnerService stadiumOwnerService;
-    private final ClubMemberService clubMemberService;
 
     /**
      * 현재 세션에 존재하는 Member의 id를 반환합니다.

--- a/src/main/java/soccerfriend/service/SessionLoginService.java
+++ b/src/main/java/soccerfriend/service/SessionLoginService.java
@@ -10,13 +10,12 @@ import soccerfriend.exception.exception.NotMatchException;
 import soccerfriend.utility.InputForm.LoginRequest;
 
 import javax.servlet.http.HttpSession;
-
+import java.util.List;
 import java.util.Optional;
 
 import static soccerfriend.exception.ExceptionInfo.*;
 import static soccerfriend.utility.PasswordWarning.NO_WARNING;
-import static soccerfriend.utility.SessionKey.SESSION_LOGIN_MEMBER;
-import static soccerfriend.utility.SessionKey.SESSION_LOGIN_STADIUM_OWNER;
+import static soccerfriend.utility.SessionKey.*;
 
 @RequiredArgsConstructor
 @Service
@@ -25,6 +24,7 @@ public class SessionLoginService implements LoginService {
     private final HttpSession httpSession;
     private final MemberService memberService;
     private final StadiumOwnerService stadiumOwnerService;
+    private final ClubMemberService clubMemberService;
 
     /**
      * 현재 세션에 존재하는 Member의 id를 반환합니다.
@@ -72,6 +72,11 @@ public class SessionLoginService implements LoginService {
         }
 
         httpSession.setAttribute(SESSION_LOGIN_MEMBER, member.get().getId());
+
+        int memberId = member.get().getId();
+        List<Integer> clubIdOfMember = clubMemberService.getClubIdOfMember(memberId);
+
+        clubIdOfMember.forEach((id) -> httpSession.setAttribute(SESSION_MEMBER_JOINED_CLUB, clubIdOfMember));
         httpSession.setMaxInactiveInterval(30 * 60);
     }
 

--- a/src/main/java/soccerfriend/service/SessionLoginService.java
+++ b/src/main/java/soccerfriend/service/SessionLoginService.java
@@ -10,12 +10,12 @@ import soccerfriend.exception.exception.NotMatchException;
 import soccerfriend.utility.InputForm.LoginRequest;
 
 import javax.servlet.http.HttpSession;
-import java.util.List;
 import java.util.Optional;
 
 import static soccerfriend.exception.ExceptionInfo.*;
 import static soccerfriend.utility.PasswordWarning.NO_WARNING;
-import static soccerfriend.utility.SessionKey.*;
+import static soccerfriend.utility.SessionKey.SESSION_LOGIN_MEMBER;
+import static soccerfriend.utility.SessionKey.SESSION_LOGIN_STADIUM_OWNER;
 
 @RequiredArgsConstructor
 @Service
@@ -72,11 +72,6 @@ public class SessionLoginService implements LoginService {
         }
 
         httpSession.setAttribute(SESSION_LOGIN_MEMBER, member.get().getId());
-
-        int memberId = member.get().getId();
-        List<Integer> clubIdOfMember = clubMemberService.getClubIdOfMember(memberId);
-
-        clubIdOfMember.forEach((id) -> httpSession.setAttribute(SESSION_MEMBER_JOINED_CLUB, clubIdOfMember));
         httpSession.setMaxInactiveInterval(30 * 60);
     }
 

--- a/src/main/java/soccerfriend/utility/SessionKey.java
+++ b/src/main/java/soccerfriend/utility/SessionKey.java
@@ -7,5 +7,4 @@ public class SessionKey {
 
     public static final String SESSION_LOGIN_MEMBER = "loginMember";
     public static final String SESSION_LOGIN_STADIUM_OWNER = "stadiumOwner";
-    public static final String SESSION_MEMBER_JOINED_CLUB = "memberJoinedClub";
 }

--- a/src/main/java/soccerfriend/utility/SessionKey.java
+++ b/src/main/java/soccerfriend/utility/SessionKey.java
@@ -7,4 +7,5 @@ public class SessionKey {
 
     public static final String SESSION_LOGIN_MEMBER = "loginMember";
     public static final String SESSION_LOGIN_STADIUM_OWNER = "stadiumOwner";
+    public static final String SESSION_MEMBER_JOINED_CLUB = "memberJoinedClub";
 }

--- a/src/main/resources/mapper/BulletinMapper.xml
+++ b/src/main/resources/mapper/BulletinMapper.xml
@@ -50,4 +50,12 @@
         WHERE club_id = #{clubId}
           AND deleted = 0
     </select>
+
+    <update id="updateName">
+        UPDATE bulletin
+        SET name       = #{name},
+            updated_at = now()
+        WHERE id = #{id}
+          AND deleted = 0
+    </update>
 </mapper>

--- a/src/main/resources/mapper/ClubMemberMapper.xml
+++ b/src/main/resources/mapper/ClubMemberMapper.xml
@@ -42,6 +42,16 @@
                    )
     </select>
 
+    <select id="bulletinReadable" resultType="boolean">
+        SELECT EXISTS(
+                       SELECT *
+                       FROM club_member
+                       WHERE club_id = #{clubId}
+                         AND member_id = #{memberId}
+                         AND approved = 1
+                   )
+    </select>
+
     <select id="isApplied" resultType="boolean">
         SELECT EXISTS(
                        SELECT *
@@ -144,5 +154,11 @@
                  LEFT OUTER JOIN club_monthly_fee b
                                  ON a.id = b.club_member_id
         WHERE a.club_id = #{clubId}
+    </select>
+
+    <select id="getClubIdOfMember" resultType="int">
+        SELECT club_id
+        FROM club_member
+        WHERE member_id = #{memberId}
     </select>
 </mapper>


### PR DESCRIPTION
## 도입 배경
- 게시판의 이름을 변경하기 위해 구현
- 게시판의 카테고리를 변경할 경우 내부의 게시물도 모두 변경해야 할 수 있으므로 구현하지 않음

## 변경 사항
### 게시판 캐싱정보 삭제기능 메소드로 분리
```java
/**
     * 캐시에 저장되어 있는 해당 게시판과 관련된 정보를 모두 삭제합니다.
     *
     * @param id     게시판의 id
     * @param clubId 클럽의 id
     */
    public void deleteCache(int id, int clubId) {
        redisTemplate.delete("BULLETIN::BULLETIN" + String.valueOf(id));
        redisTemplate.delete("BULLETIN::BULLETIN CLUB" + String.valueOf(clubId));
    }
```

### 게시판 이름 변경기능 구현
```java
/**
     * 게시판의 이름을 변경합니다.
     *
     * @param id   게시판의 id
     * @param name 새로운 이름
     */
    public void updateName(int id, String name) {
        Bulletin bulletin = getBulletinById(id);
        if (bulletin == null) {
            throw new BadRequestException(BULLETIN_NOT_EXIST);
        }

        int clubId = bulletin.getClubId();
        String oldName = bulletin.getName();
        if (oldName == name) {
            throw new BadRequestException(SAME_NAME_FOR_UPDATE);
        }

        deleteCache(id, clubId);
        mapper.updateName(id, name);
    }
```