### PR TITLE
[#issue 64] postImage 삭제

### DIFF
--- a/src/main/java/soccerfriend/authentication/PostWriteAuth.java
+++ b/src/main/java/soccerfriend/authentication/PostWriteAuth.java
@@ -1,0 +1,15 @@
+package soccerfriend.authentication;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 현재 로그인한 member가 해당 post의 작성 및 수정 권한이 있는지 확인합니다.
+ * PathVaribale로 postId를 제공받아야합니다.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PostWriteAuth {
+}

--- a/src/main/java/soccerfriend/controller/PostController.java
+++ b/src/main/java/soccerfriend/controller/PostController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import soccerfriend.authentication.BulletinWriteAuth;
 import soccerfriend.authentication.NotRecentlyPost;
+import soccerfriend.authentication.PostWriteAuth;
 import soccerfriend.dto.Comment;
 import soccerfriend.dto.Comment.ContentInput;
 import soccerfriend.dto.Post;
@@ -13,6 +14,7 @@ import soccerfriend.exception.exception.BadRequestException;
 import soccerfriend.exception.exception.NoPermissionException;
 import soccerfriend.service.CommentService;
 import soccerfriend.service.LoginService;
+import soccerfriend.service.PostImageService;
 import soccerfriend.service.PostService;
 
 import java.util.List;
@@ -28,6 +30,7 @@ public class PostController {
     private final PostService postService;
     private final LoginService loginService;
     private final CommentService commentService;
+    private final PostImageService postImageService;
 
     /**
      * 특정 게시판에 게시물을 생성합니다.
@@ -123,5 +126,17 @@ public class PostController {
     @BulletinWriteAuth
     public List<Comment> getComments(@PathVariable int bulletinId, @PathVariable int postId) {
         return commentService.getCommentsByPostId(postId);
+    }
+
+    /**
+     * 이미 업로드된 게시물의 이미지를 삭제합니다. 게시물 수정권한이 있는 자만 삭제가능합니다.
+     *
+     * @param postId      게시물의 id
+     * @param postImageId 삭제하려는 이미지의 id
+     */
+    @DeleteMapping("post/{postId}/post-image/{postImageId}")
+    @PostWriteAuth
+    public void deleteImage(@PathVariable int postId, @PathVariable int postImageId) {
+        postImageService.delete(postImageId);
     }
 }

--- a/src/main/java/soccerfriend/exception/ExceptionInfo.java
+++ b/src/main/java/soccerfriend/exception/ExceptionInfo.java
@@ -19,6 +19,7 @@ public enum ExceptionInfo {
     IS_CLUB_LEADER(401, "해당 클럽의 leader는 탈퇴할 수 없습니다."),
     PAYMENT_FAIL(401, "결제에 실패했습니다."),
     NO_COMMENT_PERMISSION(401, "해당 댓글을 수정혹은 삭제할 권한이 없습니다."),
+    NO_POST_PERMISSION(401, "게시물 작성 및 수정 권한이 없습니다."),
 
     S3_NOT_WORKING(404, "s3 SDK 연동과정에서 오류가 발생했습니다."),
     TOO_MUCH_FILES(404, "파일의 개수가 3개가 넘습니다."),

--- a/src/main/java/soccerfriend/mapper/PostImageMapper.java
+++ b/src/main/java/soccerfriend/mapper/PostImageMapper.java
@@ -9,4 +9,6 @@ public interface PostImageMapper {
     public void insert(PostImage postImage);
 
     public PostImage getPostImageById(int id);
+
+    public void delete(int id);
 }

--- a/src/main/java/soccerfriend/service/PostImageService.java
+++ b/src/main/java/soccerfriend/service/PostImageService.java
@@ -79,4 +79,28 @@ public class PostImageService {
             }
         }
     }
+
+    /**
+     * 특정 id의 게시물에 업로드된 사진을 삭제합니다. 이 때 디스크에 저장된 파일은 삭제되지 않습니다.
+     *
+     * @param id 게시물에 업로드된 사진의 id
+     */
+    public void delete(int id) {
+        PostImage postImage = getPostImageById(id);
+        if (postImage == null) {
+            throw new BadRequestException(IMAGE_NOT_EXIST);
+        }
+
+        mapper.delete(id);
+    }
+
+    /**
+     * 특정 id의 게시물에 업로드된 사진을 반환합니다.
+     *
+     * @param id 게시물에 업로드된 사진의 id
+     * @return 특정 id의 게시물에 업로드된 사진
+     */
+    public PostImage getPostImageById(int id) {
+        return mapper.getPostImageById(id);
+    }
 }

--- a/src/main/resources/mapper/PostImageMapper.xml
+++ b/src/main/resources/mapper/PostImageMapper.xml
@@ -16,4 +16,11 @@
         WHERE id = #{id}
     </select>
 
+    <update id="delete">
+        UPDATE post_image
+        SET deleted    = 1,
+            updated_at = now()
+        WHERE id = #{id}
+    </update>
+
 </mapper>


### PR DESCRIPTION
## 도입배경
- 게시물을 수정할 때 이미지를 삭제할 수 있음
- 선정적이거나 폭력적인 이미지를 관리자가 삭제할 수 있음

## 변경 사항
### postImage 삭제
```java
    /**
     * 특정 id의 게시물에 업로드된 사진을 삭제합니다. 이 때 디스크에 저장된 파일은 삭제되지 않습니다.
     *
     * @param id 게시물에 업로드된 사진의 id
     */
    public void delete(int id) {
        PostImage postImage = getPostImageById(id);
        if (postImage == null) {
            throw new BadRequestException(IMAGE_NOT_EXIST);
        }

        mapper.delete(id);
    }
```

### postImage 권한 어노테이션 추가
```java
    /**
     * 특정 id의 게시물에 업로드된 사진을 삭제합니다. 이 때 디스크에 저장된 파일은 삭제되지 않습니다.
     *
     * @param id 게시물에 업로드된 사진의 id
     */
    public void delete(int id) {
        PostImage postImage = getPostImageById(id);
        if (postImage == null) {
            throw new BadRequestException(IMAGE_NOT_EXIST);
        }

        mapper.delete(id);
    }
```