### PR TITLE
[issue #66] memberServiceTest 회원가입, 탈퇴, 조회 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.353'
+
+    testCompileOnly 'org.projectlombok:lombok:1.18.12'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.12'
 }
 
 tasks.named('test') {

--- a/src/main/java/soccerfriend/service/MemberService.java
+++ b/src/main/java/soccerfriend/service/MemberService.java
@@ -34,6 +34,9 @@ public class MemberService {
      * @param member memberId, password, nickname, positionsId, addressId를 포함하는 member 객체
      */
     public void signUp(Member member) {
+        if (member == null) {
+            throw new BadRequestException(MEMBER_NOT_EXIST);
+        }
         if (isMemberIdExist(member.getMemberId())) {
             throw new DuplicatedException(ID_DUPLICATED);
         }
@@ -60,6 +63,11 @@ public class MemberService {
      * 회원정보를 삭제합니다.
      */
     public void deleteAccount(int id) {
+        Member member = getMemberById(id);
+        if (member == null) {
+            throw new BadRequestException(MEMBER_NOT_EXIST);
+        }
+
         mapper.delete(id);
     }
 
@@ -68,15 +76,6 @@ public class MemberService {
      */
     public void deletePermanently(int id) {
         mapper.deletePermanently(id);
-    }
-
-    /**
-     * 며칠 이전의 삭제된 계정들을 영구삭제합니다.
-     *
-     * @param days 영구삭제하고자 하는 계정삭제의 최소 일수
-     */
-    public void deletePermanentlyDaysBefore(int days) {
-        mapper.deletePermanentlyDaysBefore(days);
     }
 
     /**

--- a/src/test/java/soccerfriend/service/MemberServiceTest.java
+++ b/src/test/java/soccerfriend/service/MemberServiceTest.java
@@ -1,15 +1,11 @@
 package soccerfriend.service;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mindrot.jbcrypt.BCrypt;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import soccerfriend.dto.Member;
 import soccerfriend.exception.exception.BadRequestException;
@@ -19,7 +15,8 @@ import soccerfriend.mapper.MemberMapper;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
@@ -30,20 +27,8 @@ class MemberServiceTest {
     @Mock
     private MemberMapper memberMapper;
 
-    private static MockedStatic<BCrypt> mBcrypt;
-
     private Member newMember;
     private Member member;
-
-    @BeforeClass
-    public void before() {
-        mBcrypt = mockStatic(BCrypt.class);
-    }
-
-    @AfterClass
-    public void after() {
-        mBcrypt.close();
-    }
 
     @BeforeEach
     public void init() {

--- a/src/test/java/soccerfriend/service/MemberServiceTest.java
+++ b/src/test/java/soccerfriend/service/MemberServiceTest.java
@@ -1,0 +1,170 @@
+package soccerfriend.service;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mindrot.jbcrypt.BCrypt;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import soccerfriend.dto.Member;
+import soccerfriend.exception.exception.BadRequestException;
+import soccerfriend.exception.exception.DuplicatedException;
+import soccerfriend.mapper.MemberMapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Mock
+    private MemberMapper memberMapper;
+
+    private static MockedStatic<BCrypt> mBcrypt;
+
+    private Member newMember;
+    private Member member;
+
+    @BeforeClass
+    public void before() {
+        mBcrypt = mockStatic(BCrypt.class);
+    }
+
+    @AfterClass
+    public void after() {
+        mBcrypt.close();
+    }
+
+    @BeforeEach
+    public void init() {
+        newMember = Member.builder()
+                          .memberId("qwerty12345")
+                          .password("password")
+                          .email("email@gmail.com1")
+                          .nickname("Michael1")
+                          .positionsId(1)
+                          .addressId(1)
+                          .build();
+
+        member = Member.builder()
+                       .id(1)
+                       .memberId("qwerty12345")
+                       .password("password")
+                       .email("email@gmail.com1")
+                       .nickname("Michael1")
+                       .positionsId(1)
+                       .addressId(1)
+                       .build();
+    }
+
+    @Test
+    @DisplayName("정상적인 회원가입")
+    void 정상_회원가입() {
+        when(memberService.isMemberIdExist(newMember.getMemberId())).thenReturn(false);
+        when(memberService.isNicknameExist(newMember.getNickname())).thenReturn(false);
+        when(memberService.isEmailExist(newMember.getEmail())).thenReturn(false);
+
+        memberService.signUp(newMember);
+
+        verify(memberMapper).insert(any(Member.class));
+    }
+
+    @Test
+    @DisplayName("null로 회원가입")
+    void null_회원가입() {
+        assertThrows(BadRequestException.class, () -> memberService.signUp(null));
+    }
+
+    @Test
+    @DisplayName("중복된 아이디 회원가입")
+    void 중복된_아이디_회원가입() {
+        when(memberService.isMemberIdExist(newMember.getMemberId())).thenReturn(true);
+
+        assertThrows(DuplicatedException.class, () -> memberService.signUp(newMember));
+    }
+
+    @Test
+    @DisplayName("중복된 닉네임 회원가입")
+    void 중복된_닉네임_회원가입() {
+        when(memberService.isMemberIdExist(newMember.getMemberId())).thenReturn(false);
+        when(memberService.isNicknameExist(newMember.getNickname())).thenReturn(true);
+
+        assertThrows(DuplicatedException.class, () -> memberService.signUp(newMember));
+    }
+
+    @Test
+    @DisplayName("중복된 이메일 회원가입")
+    void 중복된_이메일_회원가입() {
+        when(memberService.isMemberIdExist(newMember.getMemberId())).thenReturn(false);
+        when(memberService.isNicknameExist(newMember.getNickname())).thenReturn(false);
+        when(memberService.isEmailExist(newMember.getEmail())).thenReturn(true);
+
+        assertThrows(DuplicatedException.class, () -> memberService.signUp(newMember));
+    }
+
+    @Test
+    @DisplayName("회원 삭제")
+    void 회원삭제() {
+        when(memberMapper.getMemberById(member.getId())).thenReturn(member);
+
+        memberService.deleteAccount(member.getId());
+
+        verify(memberMapper).delete(member.getId());
+    }
+
+    @Test
+    @DisplayName("null 회원 삭제")
+    void null_회원삭제() {
+        when(memberMapper.getMemberById(member.getId())).thenReturn(null);
+
+        assertThrows(BadRequestException.class, () -> memberService.deleteAccount(member.getId()));
+    }
+
+    @Test
+    @DisplayName("회원 영구 삭제")
+    void 회원영구삭제() {
+        memberService.deletePermanently(member.getId());
+
+        verify(memberMapper).deletePermanently(member.getId());
+    }
+
+    @Test
+    @DisplayName("id를 통해 member 조회")
+    void id로_member_조회() {
+        when(memberMapper.getMemberById(member.getId())).thenReturn(member);
+
+        Member testMember = memberService.getMemberById(member.getId());
+
+        assertEquals(testMember, member);
+    }
+
+    @Test
+    @DisplayName("memberId를 통해 member 조회")
+    void memberId로_MEMBER_조회() {
+        when(memberMapper.getMemberByMemberId(member.getMemberId())).thenReturn(member);
+
+        Member testMember = memberService.getMemberByMemberId(member.getMemberId());
+
+        assertEquals(testMember, member);
+    }
+
+    @Test
+    @DisplayName("이메일을 통해 member 조회")
+    void 이메일로_MEMBER_조회() {
+        when(memberMapper.getMemberByEmail(member.getEmail())).thenReturn(member);
+
+        Member testMember = memberService.getMemberByEmail(member.getEmail());
+
+        assertEquals(testMember, member);
+    }
+}

--- a/src/test/java/soccerfriend/service/MemberServiceTest.java
+++ b/src/test/java/soccerfriend/service/MemberServiceTest.java
@@ -1,7 +1,5 @@
 package soccerfriend.service;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,7 +17,8 @@ import soccerfriend.mapper.MemberMapper;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
@@ -34,16 +33,6 @@ class MemberServiceTest {
 
     private Member newMember;
     private Member member;
-
-    @BeforeClass
-    public void before() {
-        mBcrypt = mockStatic(BCrypt.class);
-    }
-
-    @AfterClass
-    public void after() {
-        mBcrypt.close();
-    }
 
     @BeforeEach
     public void init() {


### PR DESCRIPTION
memberServiceTest 회원가입, 탈퇴, 조회에 관한 부분의 테스트코드를 작성했습니다.

feat/70에서 더 추가될 예정입니다.